### PR TITLE
Add AGENTS.md for repository overview and documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Repository Overview
+
+This is a **documentation-only repository** for the API Chat VS Code extension. It contains the public-facing documentation (README, images/GIFs), issue/PR templates, and license. The actual VS Code extension source code is maintained separately.
+
+The API Chat extension uses natural language to interact with APIs that have an OpenAPI description, intelligently selecting and calling relevant API resources based on user input in VS Code.
+
+## Repository Structure
+
+- `README.md` — Main documentation for the extension (usage, features, authentication)
+- `docs/api-chat-extension/images/` — GIFs and screenshots demonstrating extension features
+- `issue_template.md` — WSO2 standard issue template
+- `pull_request_template.md` — WSO2 standard PR template
+- `LICENSE` — Apache License 2.0
+
+## No Build/Test/Lint
+
+There are no build scripts, test suites, linting configurations, or package managers in this repository. All changes are documentation and image assets.
+
+## Conventions
+
+- Follows WSO2 organizational templates for issues and PRs
+- Documentation images are stored as GIFs/PNGs in `docs/api-chat-extension/images/`
+- Licensed under Apache 2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,1 @@
-# api-chat-vscode
-
-> **Full documentation is in [AGENTS.md](./AGENTS.md).**
-> Read AGENTS.md for repository overview, architecture, build/test commands, key files, and development guidelines.
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# api-chat-vscode
+
+> **Full documentation is in [AGENTS.md](./AGENTS.md).**
+> Read AGENTS.md for repository overview, architecture, build/test commands, key files, and development guidelines.


### PR DESCRIPTION
This pull request adds a new documentation file, `AGENTS.md`, which provides an overview of the repository, its structure, and conventions. The file clarifies that the repository is documentation-only and outlines the contents and organizational standards followed.

Repository documentation improvements:

* Added `AGENTS.md` to describe the repository as documentation-only, summarize its structure, and specify conventions and licensing.## Purpose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive repository documentation describing structure, contents, documentation conventions, image handling, and Apache 2.0 licensing.
  * Added a short index file that points readers to the main repository documentation for quick reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->